### PR TITLE
Fix wait source encoding

### DIFF
--- a/adafruit_pioasm.py
+++ b/adafruit_pioasm.py
@@ -96,7 +96,7 @@ def assemble(text_program):
             if not 0 <= polarity <= 1:
                 raise RuntimeError("Invalid polarity")
             assembled[-1] |= polarity << 7
-            assembled[-1] |= WAIT_SOURCES.index(instruction[2]) << 4
+            assembled[-1] |= WAIT_SOURCES.index(instruction[2]) << 5
             num = int(instruction[3])
             if not 0 <= num <= 31:
                 raise RuntimeError("Wait num out of range")


### PR DESCRIPTION
Change the wait instruction encoding to shift the source by 5 bits instead of 4.