### PR TITLE
split instructions on commas and whitespace

### DIFF
--- a/adafruit_pioasm.py
+++ b/adafruit_pioasm.py
@@ -14,7 +14,7 @@ Simple assembler to convert pioasm to bytes
 import array
 import re
 
-splitter = re.compile(r',\s*|\s+(?:,\s*)?').split
+splitter = re.compile(r",\s*|\s+(?:,\s*)?").split
 
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_PIOASM.git"

--- a/adafruit_pioasm.py
+++ b/adafruit_pioasm.py
@@ -12,6 +12,9 @@ Simple assembler to convert pioasm to bytes
 """
 
 import array
+import re
+
+splitter = re.compile(r',\s*|\s+(?:,\s*)?').split
 
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_PIOASM.git"
@@ -61,7 +64,7 @@ def assemble(text_program):
     assembled = []
     for instruction in instructions:
         # print(instruction)
-        instruction = instruction.split()
+        instruction = splitter(instruction.strip())
         delay = 0
         if instruction[-1].endswith("]"):  # Delay
             delay = int(instruction[-1].strip("[]"))


### PR DESCRIPTION
All of the following now parse as `["mov", "pins", "1"]` and assemble to 0x6001:
```
out pins , 1 ;
out pins, 1  ;
out pins,1   ;
out pins ,1  ;
out pins 1   ;
```

This brings pioasm closer to what upstream's examples show

Closes: #7