### PR TITLE
Create button_pio.py

### DIFF
--- a/examples/button_pio.py
+++ b/examples/button_pio.py
@@ -1,3 +1,24 @@
+'''
+written by Parsko Apr 12, 2021
+
+This is an example of how to use the PIO for a button.
+This code is derived from the encoder code.
+
+Connect a button between a ground (GND) pin and D4.
+Edit the pin (~line 73) as needed for your own use.
+
+If you open the serial REPL it prints...
+'i' is the button state, which times out and counts
+up.  Used to check for bouncing.  Mine didn't seem to bounce,
+or my code was bad?
+'button_d4:' is the switch value, without timing out.
+'time:' is the time elapsed since last button pressed, used
+for checking bouncing.
+
+I won't know for sure if the bouncing works or not
+until I have it connected to something like a motor drive.
+
+'''
 import adafruit_pioasm
 import board
 import rp2pio
@@ -34,9 +55,6 @@ class button:
             in_shift_right=False,
         )
 
-        self._counter = 0
-        self._direction = 0
-        self._lut_index = 0
         self._buffer = bytearray(1)
 
 
@@ -47,15 +65,39 @@ class button:
     def value(self):
         while self._sm.in_waiting:
             self._sm.readinto(self._buffer)
-            #self._update_state_machine(self._buffer[0])
         return self._buffer[0]
 
 
-button_d4 = button(board.D4)
+if __name__ == "__main__":
+    try:
 
-old_value = None
-while True:
-    value = button_d4.value
-    if old_value != value:
-        print("Encoder:", value)
-        time.sleep(0.01)
+        button_d4 = button(board.D4)
+        i = 0
+        start_time = time.monotonic_ns()
+        press_time = start_time
+        previous_value = button_d4.value
+        while True:
+            value = button_d4.value
+
+            print('i: ',i,"  button_d4:", value, 'time:',start_time-press_time)
+            time.sleep(0.1)
+
+            if previous_value != value and value == 0:
+                i += 1
+                press_time = time.monotonic_ns()
+
+            if previous_value != value and value == 1:
+                i = press_time = 0
+
+            if start_time - press_time > 1000000000:
+                i = 0
+
+            start_time = time.monotonic_ns()
+            previous_value = value
+
+    except Exception as e:
+        print(e)
+    except KeyboardInterrupt:
+        print('Keyboard Interupt, ending routine')
+    finally:
+        button_d4.deinit()

--- a/examples/button_pio.py
+++ b/examples/button_pio.py
@@ -1,0 +1,61 @@
+import adafruit_pioasm
+import board
+import rp2pio
+import array
+import digitalio
+import time
+
+
+class button:
+    _sm_code = adafruit_pioasm.assemble(
+        """
+    again:
+        in pins, 1
+        mov x, isr
+        jmp x!=y, push_data
+        mov isr, null
+        jmp again
+    push_data:
+        push
+        mov y, x
+    """
+    )
+
+    _sm_init = adafruit_pioasm.assemble("set y 31") # I am not sure what this does.
+
+    def __init__(self, pin_a):
+        self._sm = rp2pio.StateMachine(
+            self._sm_code,
+            2000,
+            init=self._sm_init,
+            first_in_pin=pin_a,
+            in_pin_count=1,
+            pull_in_pin_up=0b1,
+            in_shift_right=False,
+        )
+
+        self._counter = 0
+        self._direction = 0
+        self._lut_index = 0
+        self._buffer = bytearray(1)
+
+
+    def deinit(self):
+        self._sm.deinit()
+
+    @property
+    def value(self):
+        while self._sm.in_waiting:
+            self._sm.readinto(self._buffer)
+            #self._update_state_machine(self._buffer[0])
+        return self._buffer[0]
+
+
+button_d4 = button(board.D4)
+
+old_value = None
+while True:
+    value = button_d4.value
+    if old_value != value:
+        print("Encoder:", value)
+        time.sleep(0.01)

--- a/examples/button_pio.py
+++ b/examples/button_pio.py
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2021 Parsko
+#
+# SPDX-License-Identifier: MIT
+
+
 '''
 written by Parsko Apr 12, 2021
 


### PR DESCRIPTION
Hi,

I am not sure if this is the correct way to do this (propose this code), and I apologize in advance if it is not.  I tweaked the encoder example to create a button example.  This is my first time playing with PIO.  I'm pretty sure the read pin state loop could be only 2-3 lines long, but I left things as they were.  I felt this library needed a button example, for the next Parsko that shows up.

I'm unclear what line 34 is about.  I see the need I think, but don't understand what or why "set y 31".  Is it arbitrary?  

I plan on trying the encoder example with some higher line count rotaries to see if it loses counts.  So, I still need to understand the code where this came from.

Thanks,

-Parsko