### PR TITLE
Remove the "not available on PyPI yet" note.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,8 +32,6 @@ This is easily achieved by downloading
 
 Installing from PyPI
 =====================
-.. note:: This library is not available on PyPI yet. Install documentation is included
-   as a standard element. Stay tuned for PyPI availability!
 
 On supported GNU/Linux systems like the Raspberry Pi, you can install the driver locally `from
 PyPI <https://pypi.org/project/adafruit-circuitpython-pioasm/>`_. To install for current user:


### PR DESCRIPTION
It appears to be obsolete given the validity of the link just below.