### PR TITLE
Add helpful wrappers for errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ bundles
 dist
 **/*.egg-info
 .vscode
+.venv

--- a/adafruit_pioasm.py
+++ b/adafruit_pioasm.py
@@ -103,7 +103,9 @@ def assemble(text_program):
                 raise SyntaxError(f"Invalid jmp target {repr(target)}")
 
             if len(instruction) > 2:
-                assembled[-1] |= CONDITIONS.index(instruction[1]) << 5
+                try:
+                    assembled[-1] |= CONDITIONS.index(instruction[1]) << 5
+                raise SyntaxError(f"Invalid jmp condition {instruction[1]}")
 
         elif instruction[0] == "wait":
             #                instr delay p sr index
@@ -183,7 +185,10 @@ def assemble(text_program):
         elif instruction[0] == "set":
             #                instr delay dst data
             assembled.append(0b111_00000_000_00000)
-            assembled[-1] |= SET_DESTINATIONS.index(instruction[1]) << 5
+            try:
+                assembled[-1] |= SET_DESTINATIONS.index(instruction[1]) << 5
+            except ValueError:
+                raise RuntimeError(f"Uknnown set destination {instruction[1]}")
             value = int(instruction[-1])
             if not 0 <= value <= 31:
                 raise RuntimeError("Set value out of range")

--- a/adafruit_pioasm.py
+++ b/adafruit_pioasm.py
@@ -106,7 +106,9 @@ def assemble(text_program):
                 try:
                     assembled[-1] |= CONDITIONS.index(instruction[1]) << 5
                 except ValueError as exc:
-                    raise SyntaxError(f"Invalid jmp condition {instruction[1]}") from exc
+                    raise SyntaxError(
+                        f"Invalid jmp condition {instruction[1]}"
+                    ) from exc
 
         elif instruction[0] == "wait":
             #                instr delay p sr index

--- a/adafruit_pioasm.py
+++ b/adafruit_pioasm.py
@@ -105,8 +105,8 @@ def assemble(text_program):
             if len(instruction) > 2:
                 try:
                     assembled[-1] |= CONDITIONS.index(instruction[1]) << 5
-                except ValueError:
-                    raise SyntaxError(f"Invalid jmp condition {instruction[1]}")
+                except ValueError as exc:
+                    raise SyntaxError(f"Invalid jmp condition {instruction[1]}") from exc
 
         elif instruction[0] == "wait":
             #                instr delay p sr index
@@ -154,7 +154,10 @@ def assemble(text_program):
             source = instruction[-1]
             source_split = mov_splitter(source)
             if len(source_split) == 1:
-                assembled[-1] |= MOV_SOURCES.index(source)
+                try:
+                    assembled[-1] |= MOV_SOURCES.index(source)
+                except ValueError as exc:
+                    raise RuntimeError("Invalid mov source:", source) from exc
             else:
                 assembled[-1] |= MOV_SOURCES.index(source_split[1])
                 if source[:1] == "!":
@@ -188,8 +191,8 @@ def assemble(text_program):
             assembled.append(0b111_00000_000_00000)
             try:
                 assembled[-1] |= SET_DESTINATIONS.index(instruction[1]) << 5
-            except ValueError:
-                raise RuntimeError(f"Uknnown set destination {instruction[1]}")
+            except ValueError as exc:
+                raise RuntimeError(f"Uknnown set destination {instruction[1]}") from exc
             value = int(instruction[-1])
             if not 0 <= value <= 31:
                 raise RuntimeError("Set value out of range")

--- a/adafruit_pioasm.py
+++ b/adafruit_pioasm.py
@@ -192,7 +192,7 @@ def assemble(text_program):
             try:
                 assembled[-1] |= SET_DESTINATIONS.index(instruction[1]) << 5
             except ValueError as exc:
-                raise RuntimeError(f"Uknnown set destination {instruction[1]}") from exc
+                raise RuntimeError(f"Unknown set destination {instruction[1]}") from exc
             value = int(instruction[-1])
             if not 0 <= value <= 31:
                 raise RuntimeError("Set value out of range")

--- a/adafruit_pioasm.py
+++ b/adafruit_pioasm.py
@@ -105,7 +105,8 @@ def assemble(text_program):
             if len(instruction) > 2:
                 try:
                     assembled[-1] |= CONDITIONS.index(instruction[1]) << 5
-                raise SyntaxError(f"Invalid jmp condition {instruction[1]}")
+                except ValueError:
+                    raise SyntaxError(f"Invalid jmp condition {instruction[1]}")
 
         elif instruction[0] == "wait":
             #                instr delay p sr index

--- a/adafruit_pioasm.py
+++ b/adafruit_pioasm.py
@@ -106,8 +106,8 @@ def assemble(text_program):
                 try:
                     assembled[-1] |= CONDITIONS.index(instruction[1]) << 5
                 except ValueError as exc:
-                    raise SyntaxError(
-                        f"Invalid jmp condition {instruction[1]}"
+                    raise ValueError(
+                        f"Invalid jmp condition '{instruction[1]}'"
                     ) from exc
 
         elif instruction[0] == "wait":
@@ -159,7 +159,7 @@ def assemble(text_program):
                 try:
                     assembled[-1] |= MOV_SOURCES.index(source)
                 except ValueError as exc:
-                    raise RuntimeError("Invalid mov source:", source) from exc
+                    raise ValueError(f"Invalid mov source '{source}'") from exc
             else:
                 assembled[-1] |= MOV_SOURCES.index(source_split[1])
                 if source[:1] == "!":
@@ -194,7 +194,7 @@ def assemble(text_program):
             try:
                 assembled[-1] |= SET_DESTINATIONS.index(instruction[1]) << 5
             except ValueError as exc:
-                raise RuntimeError(f"Unknown set destination {instruction[1]}") from exc
+                raise ValueError(f"Invalid set destination '{instruction[1]}'") from exc
             value = int(instruction[-1])
             if not 0 <= value <= 31:
                 raise RuntimeError("Set value out of range")


### PR DESCRIPTION
These wrappers make errors a bit more descriptive than "not in sequence". 