### PR TITLE
Run mypy during pre-commit to verify typing information

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,7 +49,7 @@ repos:
     hooks:
     - id: mypy
       name: mypy
-      entry: "python3 run_mypy.py"
+      entry: "python3 etc/run_mypy.py"
       language: python
       additional_dependencies: ["mypy==0.790", "tomlkit"]
       types: [python]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,3 +40,21 @@ repos:
         files: "^tests/"
         args:
           - --disable=missing-docstring,consider-using-f-string,duplicate-code
+  - repo: local
+  # We do not use pre-commit/mirrors-mypy,
+  # as it comes with opinionated defaults
+  # (like --ignore-missing-imports)
+  # and is difficult to configure to run
+  # with the dependencies correctly installed.
+    hooks:
+    - id: mypy
+      name: mypy
+      entry: "python3 run_mypy.py"
+      language: python
+      additional_dependencies: ["mypy==0.790", "tomlkit"]
+      types: [python]
+      # use require_serial so that script
+      # is only called once per commit
+      require_serial: true
+      # Print the number of files as a sanity-check
+      verbose: true

--- a/etc/run_mypy.py
+++ b/etc/run_mypy.py
@@ -15,7 +15,7 @@ def print_check_call(command):
     subprocess.check_call(command)
 
 
-os.chdir(pathlib.Path(__file__).parent)
+os.chdir(pathlib.Path(__file__).parent.parent)
 
 pip_command = ["pip", "install", "--no-input", "--quiet", "--editable", "."]
 print_check_call(pip_command)

--- a/run_mypy.py
+++ b/run_mypy.py
@@ -1,0 +1,33 @@
+#!/usr/bin/python3
+# SPDX-FileCopyrightText: 2022 Jeff Epler, written for Adafruit Industries
+#
+# SPDX-License-Identifier: Unlicense
+"""Automatically run mypy. Use from pre-commit"""
+import os
+import pathlib
+import subprocess
+import tomlkit
+
+
+def print_check_call(command):
+    """Keep the user aware of commands being executed"""
+    print("# Running", " ".join(command))
+    subprocess.check_call(command)
+
+
+os.chdir(pathlib.Path(__file__).parent)
+
+pip_command = ["pip", "install", "--no-input", "--quiet", "--editable", "."]
+print_check_call(pip_command)
+
+with open("pyproject.toml") as f:
+    meta = tomlkit.load(f)
+mypy_command = ["mypy"]
+if meta["tool"].get("adafruit", {}).get("mypy-strict", True):
+    mypy_command.append("--strict")
+for module in meta["tool"]["setuptools"].get("py-modules", []):
+    mypy_command.extend(["-m", module])
+for module in meta["tool"]["setuptools"].get("packages", []):
+    mypy_command.extend(["-p", module])
+
+print_check_call(mypy_command)


### PR DESCRIPTION
This is a proof of concept and request for comments: When libraries are fully typed, we can and should make sure that stays true by running mypy in pre-commit.

The script automatically detects the packages and/or modules to run on.

A package may opt into non-strict mypy mode with a stanza in pyproject.toml:
```
[tool.adafruit]
    mypy-strict = false
```

I tested it also on Adafruit_CircuitPython_LED_Animation and that package is just a few changes away from passing mypy in non-strict mode.

This is based on the ideas from https://jaredkhan.com/blog/mypy-pre-commit