### PR TITLE
morse example: add missing pio_kwargs to constructor call

### DIFF
--- a/examples/pioasm_background_morse.py
+++ b/examples/pioasm_background_morse.py
@@ -69,6 +69,7 @@ sm = StateMachine(
     pull_threshold=16,
     auto_pull=True,
     out_shift_right=False,
+    **pio_code.pio_kwargs,
 )
 
 # To simply repeat 'TEST' forever, change to 'if True':


### PR DESCRIPTION
This appears to be the cause of a user's problems in #55.