### PR TITLE
support .offset pseudo-op

### DIFF
--- a/adafruit_pioasm.py
+++ b/adafruit_pioasm.py
@@ -52,6 +52,7 @@ class Program:  # pylint: disable=too-few-public-methods
         sideset_enable = 0
         wrap = None
         wrap_target = None
+        offset = -1
         for i, line in enumerate(text_program.split("\n")):
             line = line.strip()
             if not line:
@@ -62,6 +63,8 @@ class Program:  # pylint: disable=too-few-public-methods
                 if program_name:
                     raise RuntimeError("Multiple programs not supported")
                 program_name = line.split()[1]
+            elif line.startswith(".offset"):
+                offset = int(line.split()[1], 0)
             elif line.startswith(".wrap_target"):
                 wrap_target = len(instructions)
             elif line.startswith(".wrap"):
@@ -226,6 +229,9 @@ class Program:  # pylint: disable=too-few-public-methods
         self.pio_kwargs = {
             "sideset_enable": sideset_enable,
         }
+
+        if offset != -1:
+            self.pio_kwargs["offset"] = offset
 
         if sideset_count != 0:
             self.pio_kwargs["sideset_pin_count"] = sideset_count

--- a/tests/test_pseudo.py
+++ b/tests/test_pseudo.py
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: 2021 Jeff Epler, written for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
+"""
+Tests pseudo-ops
+"""
+
+from pytest_helpers import assert_pio_kwargs
+
+
+def test_offset():
+    assert_pio_kwargs(".offset 7", offset=7, sideset_enable=False)


### PR DESCRIPTION
Accompanies https://github.com/adafruit/circuitpython/pull/8223 so that a program can include its required offset in the source as a ".offset" directive.