### PR TITLE
Better diagnose the incorrect lines like "side 1" or "[5]"

### DIFF
--- a/adafruit_pioasm.py
+++ b/adafruit_pioasm.py
@@ -94,14 +94,14 @@ class Program:  # pylint: disable=too-few-public-methods
         for line in instructions:
             instruction = splitter(line.strip())
             delay = 0
-            if instruction[-1].endswith("]"):  # Delay
+            if len(instruction) > 1 and instruction[-1].endswith("]"):  # Delay
                 delay = int(instruction[-1].strip("[]"), 0)
                 if delay < 0:
                     raise RuntimeError("Delay negative:", delay)
                 if delay > max_delay:
                     raise RuntimeError("Delay too long:", delay)
                 instruction.pop()
-            if len(instruction) > 1 and instruction[-2] == "side":
+            if len(instruction) > 2 and instruction[-2] == "side":
                 if sideset_count == 0:
                     raise RuntimeError("No side_set count set")
                 sideset_value = int(instruction[-1], 0)
@@ -236,7 +236,7 @@ class Program:  # pylint: disable=too-few-public-methods
                     raise RuntimeError("Set value out of range")
                 assembled[-1] |= value
             else:
-                raise RuntimeError("Unknown instruction:" + instruction[0])
+                raise RuntimeError(f"Unknown instruction: {instruction[0]}")
             assembled[-1] |= delay << 8
             # print(bin(assembled[-1]))
 

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: KB Sriram
+#
+# SPDX-License-Identifier: MIT
+
+"""
+Tests out
+"""
+
+from pytest_helpers import assert_assembly_fails
+
+
+def test_invalid_sideset() -> None:
+    source = [
+        ".side_set 2",
+        "side 2 [5]",
+    ]
+    assert_assembly_fails(
+        "\n".join(source), match="Unknown instruction: side", errtype=RuntimeError
+    )
+
+    source = [
+        ".side_set 2",
+        "side 2",
+    ]
+    assert_assembly_fails(
+        "\n".join(source), match="Unknown instruction: side", errtype=RuntimeError
+    )
+
+
+def test_invalid_delay() -> None:
+    assert_assembly_fails(
+        "[5]", match=r"Unknown instruction: \[5\]", errtype=RuntimeError
+    )
+
+
+def test_invalid_instruction() -> None:
+    assert_assembly_fails(
+        "bad", match=r"Unknown instruction: bad", errtype=RuntimeError
+    )


### PR DESCRIPTION
Before this, the exception would be 'IndexError: list index out of range'. Now it is 'Unknown instruction: side' or similar.

Based on a report on discord from @AcThPaU that I have interpreted as actually being due to poor reporting of this error condition:
>   the pioasm sideset instruction check pops the instruction empty, causes the next nop check to out of index

side-set and delay need an instruction, even if it's `nop`. E.g., `nop side 1` instead of `side 1`. Such as [this example from pico-examples](https://github.com/raspberrypi/pico-examples/blob/master/pio/apa102/apa102.pio#L14C1-L17C1):
```
    out pins, 1   side 0   ; Stall here when no data (still asserts clock low)
    nop           side 1
```

Please feel free to expand on what you meant @AcThPaU if this doesn't address your concern.