### PR TITLE
Add public_labels, test of labels

### DIFF
--- a/adafruit_pioasm.py
+++ b/adafruit_pioasm.py
@@ -58,7 +58,7 @@ class Program:  # pylint: disable=too-few-public-methods
     assembled: array.array
     """The assembled PIO program instructions"""
     public_labels: dict[str, int]
-    """The offset of any labels delcared public"""
+    """The offset of any labels declared public"""
     pio_kwargs: dict[str, Any]
     """Settings from assembler directives to pass to the StateMachine constructor"""
 

--- a/tests/test_label.py
+++ b/tests/test_label.py
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: 2024 Jeff Epler for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
+"""
+Tests out
+"""
+
+from pytest_helpers import assert_assembly_fails
+import adafruit_pioasm
+
+
+def test_label() -> None:
+    source = [
+        "    jmp label1",
+        "label1:",
+        "    jmp label2",
+        "public label2:",
+        "    nop",
+    ]
+    program = adafruit_pioasm.Program("\n".join(source))
+    assert program.public_labels == {"label2": 2}
+
+    # Test each combination of public/privagte label duplication
+    source = [
+        "label1:\n",
+        "nop\n",
+        "public label1:\n",
+        "nop\n",
+    ]
+    assert_assembly_fails(
+        "\n".join(source), match="Duplicate label", errtype=SyntaxError
+    )
+
+    source = [
+        "label1:\n",
+        "    nop\n",
+        "label1:\n",
+        "    nop\n",
+    ]
+    assert_assembly_fails(
+        "\n".join(source), match="Duplicate label", errtype=SyntaxError
+    )
+
+    source = [
+        "public label1:\n",
+        "    nop\n",
+        "label1:\n",
+        "    nop\n",
+    ]
+    assert_assembly_fails(
+        "\n".join(source), match="Duplicate label", errtype=SyntaxError
+    )
+
+    source = [
+        "public label1:\n",
+        "    nop\n",
+        "public label1:\n",
+        "    nop\n",
+    ]
+    assert_assembly_fails(
+        "\n".join(source), match="Duplicate label", errtype=SyntaxError
+    )


### PR DESCRIPTION
Now, a label declared with `public foo:` will be exported in the `public_labels` property of `Program` objects.

Additionally, a test of this feature as well as the existing duplicate label detection feature is added.

Change the return type of `assemble` so that it better reflects reality

Add docstrings for the public properties of Program objects

Closes #62 (alternative to offered PR)