### PR TITLE
Use higher frequency values

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -75,7 +75,7 @@ Usage Example
 
     sm = rp2pio.StateMachine(
         assembled,
-        frequency=2000,
+        frequency=4000,
         init=adafruit_pioasm.assemble("set pindirs 1"),
         first_set_pin=board.LED,
     )

--- a/examples/pioasm_7seg.py
+++ b/examples/pioasm_7seg.py
@@ -116,7 +116,7 @@ class SMSevenSegment:
         self._buf = array.array("H", (DIGITS_WT[0] & ~COM_WT[i] for i in range(4)))
         self._sm = rp2pio.StateMachine(
             _program.assembled,
-            frequency=2000,
+            frequency=4000,
             first_out_pin=first_pin,
             out_pin_count=14,
             auto_pull=True,

--- a/examples/pioasm_hello.py
+++ b/examples/pioasm_hello.py
@@ -27,7 +27,7 @@ assembled = adafruit_pioasm.assemble(hello)
 
 sm = rp2pio.StateMachine(
     assembled,
-    frequency=2000,
+    frequency=4000,
     first_out_pin=board.LED,
 )
 print("real frequency", sm.frequency)


### PR DESCRIPTION
With high CPU frequency in use by default on the Pico RP2040 the current frequency values raise `ValueError: frequency out of range`

This updates them to a larger value which succeeds under the default configuration. 